### PR TITLE
Changed how segments were ordered for backwards compatibility

### DIFF
--- a/packages/visual-utils/src/calculateSegments.ts
+++ b/packages/visual-utils/src/calculateSegments.ts
@@ -23,7 +23,6 @@
  */
 
 import * as d3 from 'd3'
-import * as _ from 'lodash'
 import { fullColors } from '@essex/visual-styling'
 import { IGradient } from './interfaces'
 
@@ -77,20 +76,29 @@ export default function calculateSegments(
 			.range([startColor as any, endColor as any])
 	}
 
-	return _.sortBy(segmentInfo, ['name']).map((v, i) => {
-		let color = fullColors[i]
-		if (segmentColors && segmentColors[i]) {
-			color = segmentColors[i].color
-		} else if (gradientScale) {
-			color = gradientScale(isNaN(v.name) ? i : v.name) as any
-		} else {
-			color = defaultColor || fullColors[i]
-		}
-		color = color || '#ccc'
-		return {
-			name: v.name,
-			identity: v.identity,
-			color
-		}
-	})
+	return segmentInfo
+		.sort((a, b) => {
+			if ((!a && b) || a.name < b.name) {
+				return -1
+			} else if ((a && !b) || a.name > b.name) {
+				return 1
+			}
+			return 0
+		})
+		.map((v, i) => {
+			let color = fullColors[i]
+			if (segmentColors && segmentColors[i]) {
+				color = segmentColors[i].color
+			} else if (gradientScale) {
+				color = gradientScale(isNaN(v.name) ? i : v.name) as any
+			} else {
+				color = defaultColor || fullColors[i]
+			}
+			color = color || '#ccc'
+			return {
+				name: v.name,
+				identity: v.identity,
+				color
+			}
+		})
 }

--- a/packages/visual-utils/src/calculateSegments.ts
+++ b/packages/visual-utils/src/calculateSegments.ts
@@ -85,19 +85,20 @@ export default function calculateSegments(
 			}
 			return 0
 		})
-		.map((v, i) => {
+		.map((si, i) => {
+			const { name, identity } = si
 			let color = fullColors[i]
 			if (segmentColors && segmentColors[i]) {
 				color = segmentColors[i].color
 			} else if (gradientScale) {
-				color = gradientScale(isNaN(v.name) ? i : v.name) as any
+				color = gradientScale(isNaN(name) ? i : name) as any
 			} else {
 				color = defaultColor || fullColors[i]
 			}
 			color = color || '#ccc'
 			return {
-				name: v.name,
-				identity: v.identity,
+				name,
+				identity,
 				color
 			}
 		})


### PR DESCRIPTION
It currently works by sorting segments by their name in a natural order, so numerical names would be sorted like: `["1", "9", "10"]`.  However, the way it was sorting before was purely alphabetically, so numerical names would be sorted like: `["1", "10", "9"]`.  This pull request returns to the later sorting method. 