### PR TITLE
Replaced complete lodash with partial functions

### DIFF
--- a/packages/visual-settings/package.json
+++ b/packages/visual-settings/package.json
@@ -27,7 +27,6 @@
     "@essex/visual-utils": "^2.0.4",
     "font-awesome": "^4.6.1",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "3.6.0",
     "lodash.assignin": "^4.2.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",

--- a/packages/visual-settings/src/decorators.ts
+++ b/packages/visual-settings/src/decorators.ts
@@ -30,7 +30,7 @@ import {
 } from './interfaces'
 import { colorParser, colorCategoricalInstanceObjectParser } from './parsers'
 import { coloredObjectInstanceComposer, colorComposer } from './composers'
-import * as _ from 'lodash'
+const merge = require('lodash.merge') // tslint:disable-line
 
 /**
  * Defines the type for a color in powerbi
@@ -76,7 +76,7 @@ export function numberSetting<T>(config?: ISettingDescriptor<T>) {
  */
 export function jsonSetting<J, T>(config?: ISettingDescriptor<T>) {
 	'use strict'
-	config = _.merge(
+	config = merge(
 		{},
 		{
 			config: {
@@ -129,7 +129,7 @@ export function instanceColorSetting<T>(
 	config?: IColorInstanceSettingDescriptor<T>
 ) {
 	'use strict'
-	config = _.merge(
+	config = merge(
 		{},
 		{
 			config: {
@@ -184,7 +184,7 @@ export function enumSetting<T>(enumType: any, config?: ISettingDescriptor<T>) {
  */
 function typedSetting<T>(type: any, config?: ISettingDescriptor<T>) {
 	'use strict'
-	config = _.merge(
+	config = merge(
 		{},
 		{
 			config: {

--- a/packages/visual-utils/package.json
+++ b/packages/visual-utils/package.json
@@ -26,10 +26,12 @@
     "@essex/visual-styling": "^2.0.0",
     "debug": "^2.2.0",
     "font-awesome": "^4.6.1",
-    "lodash": "3.6.0",
     "lodash.assignin": "^4.2.0",
     "lodash.get": "^4.4.2",
+    "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.0",
+    "lodash.pick": "^4.4.0",
+    "lodash.some": "^4.6.0",
     "powerbi-models": "^0.11.3",
     "powerbi-visuals-tools": "^1.7.0"
   }

--- a/packages/visual-utils/src/calcUpdateType.ts
+++ b/packages/visual-utils/src/calcUpdateType.ts
@@ -24,7 +24,9 @@
 import VisualUpdateOptions = powerbi.extensibility.visual.VisualUpdateOptions
 import UpdateType from './UpdateType'
 const assignIn = require('lodash.assignin') // tslint:disable-line
-import * as _ from 'lodash'
+const ldIsEqual = require('lodash.isequal') // tslint:disable-line
+const pick = require('lodash.pick') // tslint:disable-line
+const some = require('lodash.some') // tslint:disable-line
 
 export const DEFAULT_CALCULATE_SETTINGS: ICalcUpdateTypeOptions = {
 	checkHighlights: false,
@@ -118,7 +120,7 @@ function hasSettingsChanged(
 	for (let i = 0; i < oldDvs.length; i++) {
 		const oM: any = oldDvs[i].metadata || {}
 		const nM: any = dvs[i].metadata || {}
-		if (!_.isEqual(oM.objects, nM.objects)) {
+		if (!ldIsEqual(oM.objects, nM.objects)) {
 			return true
 		}
 	}
@@ -179,7 +181,7 @@ function hasArrayChanged<T>(
 			!isEqual(a1[0], a2[0]) ||
 			!isEqual(a1[last], a2[last]) ||
 			// Check everything
-			_.some(a1, (n: any, i: number) => !isEqual(n, a2[i]))
+			some(a1, (n: any, i: number) => !isEqual(n, a2[i]))
 		)
 	}
 	return false
@@ -237,9 +239,7 @@ function hasDataViewChanged(
 
 	for (let i = 0; i < cols1.length; i++) {
 		// The underlying column has changed, or if the roles have changed
-		if (
-			!_.isEqual(_.pick(cols1[i], colProps), _.pick(cols2[i], colProps))
-		) {
+		if (!ldIsEqual(pick(cols1[i], colProps), pick(cols2[i], colProps))) {
 			return true
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4823,6 +4823,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.isfunction@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
@@ -4925,6 +4929,10 @@ lodash.omit@^3.1.0:
     lodash.keysin "^3.0.0"
     lodash.restparam "^3.0.0"
 
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
@@ -4932,6 +4940,10 @@ lodash.restparam@^3.0.0:
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+
+lodash.some@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.sortby@^4.5.0:
   version "4.7.0"


### PR DESCRIPTION
Adding `visual-settings` to pbi package, brought complete lodash library to its bundle and increased the size. So I replaced the lodash with partial functions. 